### PR TITLE
Fix broken self-hosted docs links

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1170,7 +1170,13 @@ redirects:
   - source: /docs/oci
     destination: /docs/oci-docker-podman
   - source: /docs/azure
-    destination: /docs/azure-docker-podma
+    destination: /docs/azure-docker-podman
+  - source: /docs/on-prem-deployment-environments
+    destination: /docs/self-hosted-deployment-environments
+  - source: /docs/on-prem-self-service-tutorial
+    destination: /docs/self-hosted-self-service-tutorial
+  - source: /docs/on-prem-add-ons
+    destination: /docs/self-hosted-add-ons
   - source: /reference/voicebot-api-phase-preview-copy
     destination: /reference/voicebot-api-phase-preview
   - source: /docs/keep-alive

--- a/fern/docs/azure-docker-podman.mdx
+++ b/fern/docs/azure-docker-podman.mdx
@@ -88,4 +88,4 @@ What’s Next
 
 Now that we have provisioned a deployment environment, we need to start configuring it for inference.
 
-* [Deployment Environments](/docs/on-prem-deployment-environments)
+* [Drivers and Containerization Platforms](/docs/drivers-and-containerization-platforms)

--- a/fern/docs/self-hosted-introduction.mdx
+++ b/fern/docs/self-hosted-introduction.mdx
@@ -3,11 +3,11 @@ title: Introduction
 subtitle: >-
   Deepgram supports a variety of deployment methods, including a self-hosted
   offering, which is an isolated service deployed to customer-requisitioned
-  cloud instances or on-premises data centers. This introduction opens a series
-  of guides that aim to:
+  cloud instances or on-premises data centers.
 slug: docs/self-hosted-introduction
 ---
 
+This introduction opens a series of guides that aim to:
 
 * Outline the benefits and use cases of self-hosting
 * Describe the architecture, requirements, and needed assets for an installation


### PR DESCRIPTION
This fixes a few missing redirects and incorrect links from the docs cutover.