### PR TITLE
updates overrides for async listen api

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,21 @@ fern generate --docs --preview
 
 ### Viewing Custom Components
 
-To view custom components in a Preview URL, you can run the following commands from `/deepgram-fern-config/custom-app/src` 
+To view custom components in a Preview URL, you can run the following commands from `/deepgram-fern-config/custom-app/src`
 
 ```sh
 npm i
 
 npm run build
 
+fern generate --docs --preview
+```
+
+## View API Playground Changes
+
+To view changes to the API Playground, you can run the following command
+
+```sh
 fern generate --docs --preview
 ```
 

--- a/fern/asyncapi-overrides.yml
+++ b/fern/asyncapi-overrides.yml
@@ -1,5 +1,6 @@
 channels:
   speak:
+    # Sets API Playground parameters to optional
     parameters:
       encoding:
         x-fern-optional: true
@@ -7,6 +8,7 @@ channels:
         x-fern-optional: true
       sample_rate:
         x-fern-optional: true
+    # Defines examples for the API Playground
     x-fern-examples:
       - name: Text-to-Speech Example
         summary: This is an example of a text-to-speech session
@@ -28,6 +30,73 @@ channels:
             messageId: textToSpeechResponse
             value: Y3VyaW91cyBtaW5kcyB0aGluayBhbGlrZSA6KQ==
   listen:
+    # Sets API Playground parameters to optional
+    parameters:
+      callback:
+        x-fern-optional: true
+      callback_method:
+        x-fern-optional: true
+      channels:
+        x-fern-optional: true
+      diarize:
+        x-fern-optional: true
+      diarize_version:
+        x-fern-optional: true
+      dictation:
+        x-fern-optional: true
+      encoding:
+        x-fern-optional: true
+      endpointing:
+        x-fern-optional: true
+      extra:
+        x-fern-optional: true
+      filler_words:
+        x-fern-optional: true
+      interim_results:
+        x-fern-optional: true
+      keyterm:
+        x-fern-optional: true
+      keywords:
+        x-fern-optional: true
+      language:
+        x-fern-optional: true
+      model:
+        x-fern-optional: true
+      multichannel:
+        x-fern-optional: true
+      numerals:
+        x-fern-optional: true
+      profanity_filter:
+        x-fern-optional: true
+      punctuate:
+        x-fern-optional: true
+      redact:
+        x-fern-optional: true
+      replace:
+        x-fern-optional: true
+      sample_rate:
+        x-fern-optional: true
+      search:
+        x-fern-optional: true
+      smart_format:
+        x-fern-optional: true
+      tag:
+        x-fern-optional: true
+      utterance_end:
+        x-fern-optional: true
+      vad_events:
+        x-fern-optional: true
+      version:
+        x-fern-optional: true
+    control_messages_request:
+      # Sets API Playground control messages to optional
+      Finalize:
+        x-fern-optional: true
+      CloseStream:
+        x-fern-optional: true
+      KeepAlive:
+        x-fern-optional: true
+    # Defines examples for the API Playground
     x-fern-examples:
       - name: Speech-to-Text Example
         summary: This is an example of a speech-to-text session

--- a/fern/asyncapi-overrides.yml
+++ b/fern/asyncapi-overrides.yml
@@ -88,14 +88,6 @@ channels:
         x-fern-optional: true
       version:
         x-fern-optional: true
-    control_messages_request:
-      # Sets API Playground control messages to optional
-      Finalize:
-        x-fern-optional: true
-      CloseStream:
-        x-fern-optional: true
-      KeepAlive:
-        x-fern-optional: true
     # Defines examples for the API Playground
     x-fern-examples:
       - name: Speech-to-Text Example


### PR DESCRIPTION
- sets overrides for async listen api
- updates readme to explain how to access the API Playground locally
- adds helpful comments to this config for future reference


BEFORE
<img width="719" alt="Screenshot 2025-02-24 at 4 57 01 PM" src="https://github.com/user-attachments/assets/592b254e-9665-4fd5-b7cc-3eba74d17a8d" />



AFTER
<img width="813" alt="Screenshot 2025-02-24 at 5 13 10 PM" src="https://github.com/user-attachments/assets/d1909866-444c-4020-9118-5421993f4dad" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209427878411272