### PR TITLE
update redaction for new streaming behavior

### DIFF
--- a/fern/docs/redaction.mdx
+++ b/fern/docs/redaction.mdx
@@ -8,7 +8,7 @@ slug: docs/redaction
 `redact` *string* Default: `False`
 
 <div class="flex flex-row gap-2">
-<Markdown src="../snippets/pre-recorded.mdx" /> <Markdown src="../snippets/streaming.mdx" /> <Markdown src="../snippets/en-only.mdx" />
+<Markdown src="../snippets/pre-recorded.mdx" /> <Markdown src="../snippets/streaming.mdx" /> <Markdown src="../snippets/specific-languages-only.mdx" />
 </div>
 
 <div class="api-playground-call">
@@ -78,7 +78,7 @@ Multiple types of entities can be redacted with the syntax `redact=option_1&reda
 ### Streaming
 
 <Info>
-  Using `no_delay=true` with Redaction will result in Redaction being disabled.
+   To ensure redaction occurs, set `no_delay=false` or avoid using `no_delay` altogether.
 </Info>
 
 When live-streaming audio to Deepgram's hosted endpoint, redaction options include:

--- a/fern/docs/redaction.mdx
+++ b/fern/docs/redaction.mdx
@@ -78,7 +78,7 @@ Multiple types of entities can be redacted with the syntax `redact=option_1&reda
 ### Streaming
 
 <Info>
-   To ensure redaction occurs, set `no_delay=false` or avoid using `no_delay` altogether.
+   To ensure redaction operates with the highest accuracy, set `no_delay=false` or avoid including `no_delay` altogether. If `no_delay=true` is set, our system will opt for low latency at the risk of redaction performance.
 </Info>
 
 When live-streaming audio to Deepgram's hosted endpoint, redaction options include:

--- a/fern/docs/redaction.mdx
+++ b/fern/docs/redaction.mdx
@@ -5,7 +5,7 @@ slug: docs/redaction
 ---
 
 
-`redact` *boolean* Default: `false`
+`redact` *string* Default: `False`
 
 <div class="flex flex-row gap-2">
 <Markdown src="../snippets/pre-recorded.mdx" /> <Markdown src="../snippets/streaming.mdx" /> <Markdown src="../snippets/en-only.mdx" />
@@ -77,9 +77,9 @@ Multiple types of entities can be redacted with the syntax `redact=option_1&reda
 
 ### Streaming
 
-<Warning>
-  Live streamed redaction is not currently available when using smart formatting on our Nova or enhanced models.
-</Warning>
+<Info>
+  Using `no_delay=true` with Redaction will result in Redaction being disabled.
+</Info>
 
 When live-streaming audio to Deepgram's hosted endpoint, redaction options include:
 
@@ -91,22 +91,10 @@ When live-streaming audio to Deepgram's hosted endpoint, redaction options inclu
 
 ## Results
 
-### Pre-Recorded
-
-For pre-recorded audio, redaction replaces redacted content with the type of entity redacted and the number of times that entity has been detected in the transcript. For example, if you choose to redact social security numbers, the phrase "My social security number is five five five two two one one one one and his is six six six two two one three three three" would appear in your transcript as "My social security number is \[SSN\_1] and his is \[SSN\_2]".
+For both Live-streaming and Pre-recorded audio, Redaction replaces redacted content with the type of entity redacted and the number of times that entity has been detected in the transcript. For example, if you choose to redact social security numbers, the phrase "My social security number is five five five two two one one one one and his is six six six two two one three three three" would appear in your transcript as "My social security number is \[SSN\_1] and his is \[SSN\_2]".
 
 Example with `redact=pci&redact=pii`:
 
 | Source                                                                                                                                                                                                                                                                                                                                                                                   | Before redact                                                                                                                                                                                                                                                                                                                                                                            | After redact                                                                                                                                                                                                                              |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | my credit card number is four four four four nine nine nine nine three three three three two two two two with an expiration date of one twenty three and the cvv code is one one one i live at one two three main street dallas texas seven five two zero one my phone number is five five five two one two nine three three three my date of birth is july twelfth nineteen seventy six | my credit card number is four four four four nine nine nine nine three three three three two two two two with an expiration date of one twenty three and the cvv code is one one one i live at one two three main street dallas texas seven five two zero one my phone number is five five five two one two nine three three three my date of birth is july twelfth nineteen seventy six | my credit card number is \[CREDIT\_CARD\_1] with an expiration date of \[CREDIT\_CARD\_EXPIRATION\_1] and the cv code is \[CVV\_1] i live at \[LOCATION\_ADDRESS\_1] my phone number is \[PHONE\_NUMBER\_1] my date of birth is \[DOB\_1] |
-
-### Live Streaming Audio
-
-For streaming audio, redaction replaces redacted content with asterisks (\*).
-
-Example with `redact=pci`:
-
-| Source                                                                                                                                                                                                                                                                                                                                                                                   | Before redact                                                                                                                                                                                                                                                                                                                                                                            | After redact                                                                                                                                                                                                                                         |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| my credit card number is four four four four nine nine nine nine three three three three two two two two with an expiration date of one twenty three and the cvv code is one one one i live at one two three main street dallas texas seven five two zero one my phone number is five five five two one two nine three three three my date of birth is july twelfth nineteen seventy six | my credit card number is four four four four nine nine nine nine three three three three two two two two with an expiration date of one twenty three and the cvv code is one one one i live at one two three main street dallas texas seven five two zero one my phone number is five five five two one two nine three three three my date of birth is july twelfth nineteen seventy six | my credit card number is \* with an expiration date of \* and the cvv code is \* i live at \* main street dallas texas \* my phone number is five five five two one two nine three three three my date of birth is july twelfth nineteen seventy six |

--- a/fern/snippets/specific-languages-only.mdx
+++ b/fern/snippets/specific-languages-only.mdx
@@ -1,0 +1,1 @@
+<a href="/docs/models-languages-overview" class="dg-badge pink"><span><Icon icon="language" /> Specific languages only</span></a>


### PR DESCRIPTION
- pre-recorded output  and streaming redacted output is now the same.
- no_delay=true will cause issues with redaction when streaming.
- Redaction should be documented as a string, not boolean.
-  See related Spec PR: https://github.com/deepgram/internal-api-specs/pull/79
- Live streaming redaction now works with nova models and smart formatting no need for a call out.
- Adds a specific language only component for language options.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207533846839506
  - https://app.asana.com/0/0/1208563324126249