### PR TITLE
Bump CLI version.

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "deepgram",
-  "version": "0.54.0-rc3"
+  "version": "0.54.1"
 }


### PR DESCRIPTION
This CLI version resolves the `Enum value 16000 is not suitable for code generation` error raised during `fern check`.