### PR TITLE
disables edit-this-page

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,11 +1,12 @@
 instances:
   - url: https://deepgram.docs.buildwithfern.com
     custom-domain: developers.deepgram.com
-    edit-this-page:
-      github:
-        owner: deepgram
-        repo: deepgram-fern-config
-        branch: main
+    # Disabled edit-this-page for private repo
+    # edit-this-page:
+    #   github:
+    #     owner: deepgram
+    #     repo: deepgram-fern-config
+    #     branch: main
 title: Deepgram | Documentation
 logo:
   dark: assets/logo.svg


### PR DESCRIPTION
- We've opted to disable this feature as the repo is going to be made private.
-  the feature is commented out, in case we want to use it again the future.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209505051506237